### PR TITLE
Fix dynamic params usage

### DIFF
--- a/app/ajout/[id]/numVoiture/page.tsx
+++ b/app/ajout/[id]/numVoiture/page.tsx
@@ -1,16 +1,14 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
-import type { PageProps } from 'next'; // ← 👈 voici l'import important
-
-export default function NumVoiturePage({ params }: PageProps<{ id: string }>) {
-    const [supabase, setSupabase] = useState<any>(null);
+import type { SupabaseClient } from '@supabase/supabase-js';
+export default function NumVoiturePage() {
+    const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
     const router = useRouter();
     const searchParams = useSearchParams();
+    const params = useParams<{ id: string }>();
 
     const [numeroVoiture, setNumeroVoiture] = useState('');
     const [codePorte, setCodePorte] = useState('');

--- a/app/vision/[id]/page.tsx
+++ b/app/vision/[id]/page.tsx
@@ -4,20 +4,19 @@ import {VisionHeader} from '@/app/ui/VisionHeader';
 import Link from 'next/link';
 import Image from 'next/image';
 
-type Props = {
-    params: {
-        id: string;
-    };
+type PageProps = {
+    params: Promise<{ id: string }>;
 };
 
-export default async function VisionMaterielPage({params}: Props) {
+export default async function VisionMaterielPage({ params }: PageProps) {
+    const { id } = await params;
     const supabase = await createClient();
 
     // Récupération de la ligne
     const {data: ligne} = await supabase
         .from('lignes')
         .select('*')
-        .eq('id', params.id)
+        .eq('id', id)
         .single();
 
     if (!ligne) notFound();
@@ -26,7 +25,7 @@ export default async function VisionMaterielPage({params}: Props) {
     const {data: liens, error} = await supabase
         .from('ligne_materiels')
         .select('materiel_id')
-        .eq('ligne_id', params.id);
+        .eq('ligne_id', id);
 
     if (!liens || error) {
         console.error('Erreur récupération liens ligne/matériel', error);
@@ -51,7 +50,7 @@ export default async function VisionMaterielPage({params}: Props) {
                     {materiels.map((mat) => (
                         <Link
                             key={mat.id}
-                            href={`/vision/${params.id}/table?idMateriel=${mat.id}`}
+                            href={`/vision/${id}/table?idMateriel=${mat.id}`}
                             className="group relative"
                         >
                             <div


### PR DESCRIPTION
## Summary
- use `useParams` hook in `numVoiture` client page
- adjust types and await route params in vision page
- type Supabase client properly to satisfy lint

## Testing
- `npm run lint`
- `npm run build` *(fails: Supabase credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_687828c1d4cc8324bb046d6a27717806